### PR TITLE
Make it possible to run without sentinel

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -77,6 +77,7 @@ func (a *API) handleChannel(w http.ResponseWriter, r *http.Request) *handler.Err
 	defer c.Close(websocket.StatusInternalError, "the sky is falling")
 
 	if c.Subprotocol() != subProtocol {
+		log.Println("refusing client connection: invalid subprotocol")
 		c.Close(websocket.StatusPolicyViolation, "client must speak the correct subprotocol")
 		return nil
 	}


### PR DESCRIPTION
Add a PubSub constructor for a single redis server

Add a `-redis-server-address` command-line option to connect to a redis
server without using redis sentinel.
