### PR TITLE
Abort if we can't connect to redis after 3 attempts

### DIFF
--- a/pubsub/pubsub.go
+++ b/pubsub/pubsub.go
@@ -21,9 +21,8 @@ func New(address string, password string) (*PubSub, error) {
 		return radix.Dial("tcp", address, radix.DialAuthPass(password))
 	})
 
-	conn, err := radix.PersistentPubSubWithOpts("tcp", address, connFunc)
+	conn, err := radix.PersistentPubSubWithOpts("tcp", address, connFunc, radix.PersistentPubSubAbortAfter(3))
 	if err != nil {
-		// This should never happen since we don't set a retry limit on the connection above
 		return nil, err
 	}
 


### PR DESCRIPTION
With this, if the value of `-redis-server-address` is incorrect,
message-queue will print an error and then exit.

Closes #8