### PR TITLE
Refactor Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,15 @@
 # Golang build step / Debian Buster 21.01 / Golang 1.15.7
-FROM quay.io/mullvad/golang@sha256:bed1bb603f38e0349cd06f2281b7e59a008192d8e99df4ea8792dc40950e8ab9 as gobuilder
-RUN apt-get update && apt-get install -y git
-ADD . /message-queue
+FROM golang:1.17.6@sha256:8fb6a244eeea71ca938a47eb046a39999a96ad43a0a69bf4275463df135bdc95 AS gobuilder
+ARG version
+ARG branch
+ARG revision
+COPY . /message-queue
 WORKDIR /message-queue
-# Run golang tests
-RUN make all
+RUN go install -v -ldflags="-X 'main.Branch=${branch}' -X 'main.Revision=${revision}' -X 'main.Version=${version}'" ./...
 
-# Copy go binary
-FROM quay.io/mullvad/debian@sha256:3cd089ccc7d89c2488795c8828a698baf77000791df2cd335982019ec838a849
-RUN mkdir /app
+# Copy message-queue binary
+FROM debian:stretch@sha256:4bb600434787c903886fe33526d19ff33114a33b433a4a4cdbdf9b8543f1ab5d
 WORKDIR /app
 COPY --from=gobuilder /go/bin/message-queue .
-
 EXPOSE 8080
-
 CMD ["./message-queue"]


### PR DESCRIPTION
- Bump golang version to 1.17.6
- Use golang/debian images from docker.io
- Add version/branch/revision args