### PR TITLE
Allow password to be empty

### DIFF
--- a/main.go
+++ b/main.go
@@ -85,10 +85,6 @@ func main() {
 		log.Fatalf("'-redis-sentinel-service' is required when using redis sentinel")
 	}
 
-	if *redisPassword == "" {
-		log.Fatalf("'-redis-server-password' is required")
-	}
-
 	redisSentinelAddrList := strings.Split(*redisSentinelAddrs, ",")
 
 	if *channels == "" {


### PR DESCRIPTION
This makes it easier to run message-queue in the current dev setup for
the API, where we don't have a redis password.